### PR TITLE
Made it into 'datalad dataset' and annex added virtualbox image

### DIFF
--- a/.datalad/.gitattributes
+++ b/.datalad/.gitattributes
@@ -1,0 +1,3 @@
+config annex.largefiles=nothing
+metadata/aggregate* annex.largefiles=nothing
+metadata/objects/** annex.largefiles=(largerthan=20kb)

--- a/.datalad/config
+++ b/.datalad/config
@@ -1,0 +1,2 @@
+[datalad "dataset"]
+	id = 750a4352-d62a-11e8-8f88-8019340ce7f2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* annex.backend=MD5E

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * annex.backend=MD5E
+**/.git* annex.largefiles=nothing

--- a/vm/reprotraining.ova
+++ b/vm/reprotraining.ova
@@ -1,0 +1,1 @@
+../.git/annex/objects/gx/04/MD5E-s5081213952--fc63e68b59a3afdaf6304aa05df1a162.ova/MD5E-s5081213952--fc63e68b59a3afdaf6304aa05df1a162.ova


### PR DESCRIPTION
If sounds like a good thing to do, then upon this is merged I would push git-annex branch which would provide URL (https://training.repronim.org/reprotraining.ova, pity that it is not versioned) for that file, so that (knowledgeable) people could do `git annex get` or `datalad get` on that file to retrieve it.